### PR TITLE
[FIX] Minimap icon position when UI is scaled

### DIFF
--- a/ui/MusicianButton.lua
+++ b/ui/MusicianButton.lua
@@ -20,13 +20,14 @@ function MusicianButton.Reposition()
 end
 
 function MusicianButton.DraggingFrame_OnUpdate()
-	local xpos,ypos = GetCursorPosition()
-	local xmin,ymin = Minimap:GetLeft() + Minimap:GetWidth() / 2, Minimap:GetBottom() + Minimap:GetHeight() / 2
+	local xpos, ypos = GetCursorPosition()
+	local xmin, ymin = Minimap:GetCenter()
+	local scale = UIParent:GetScale()
 
-	xpos = xpos-xmin/UIParent:GetScale()
-	ypos = ypos-ymin/UIParent:GetScale()
+	xpos = xpos / scale
+	ypos = ypos / scale
 
-	Musician_Settings.minimapPosition = math.deg(math.atan2(ypos,xpos))
+	Musician_Settings.minimapPosition = math.deg(math.atan2(ypos - ymin, xpos - xmin)) % 360
 	MusicianButton.Reposition()
 end
 
@@ -99,4 +100,3 @@ end
 function MusicianButton.HideTooltip()
 	GameTooltip:Hide();
 end
-


### PR DESCRIPTION
When the UI is scaled, the icon button can't be moved
This fix it for round minimap.
It can be easier to manage it with [libdbicon-1-0](https://www.curseforge.com/wow/addons/libdbicon-1-0)